### PR TITLE
move reusable code into a helper_macro folder.

### DIFF
--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -8,9 +8,8 @@ RSpec.describe TasksController, type: :controller do
       task1.update_attributes(title: "Something else")
       get :index
       expect(response).to have_http_status :success
-      response_value = ActiveSupport::JSON.decode(@response.body)
-      expect(response_value.count).to eq(2)
-      response_ids = response_value.map { |task| task["id"] }
+      expect(json_resp.count).to eq(2)
+      response_ids = json_resp.map { |task| task["id"] }
       expect(response_ids).to eq([task1.id, task2.id])
     end
   end

--- a/spec/helper_macros.rb
+++ b/spec/helper_macros.rb
@@ -1,0 +1,5 @@
+module HelperMacros
+  def json_resp
+    ActiveSupport::JSON.decode(@response.body)
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,8 @@ require File.expand_path('../../config/environment', __FILE__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'spec_helper'
 require 'rspec/rails'
+require 'helper_macros'
+
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -54,4 +56,5 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.include HelperMacros
 end


### PR DESCRIPTION
This pull request shows how you can move the reusable code into methods that you can access within rspec.